### PR TITLE
Handle hexadecimal CommandID strings in headless dispatch

### DIFF
--- a/teamserver/cmd/server/dispatch.go
+++ b/teamserver/cmd/server/dispatch.go
@@ -165,13 +165,15 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 							} else {
 
 								// TODO: move to own function.
-								command, err = strconv.Atoi(val.(string))
+								var parsed int64
+								parsed, err = strconv.ParseInt(val.(string), 0, 32)
 								if err != nil {
 
 									logger.Error("Failed to convert CommandID to integer: " + err.Error())
 									command = 0
 
 								} else {
+									command = int(parsed)
 									*Message = make(map[string]string)
 
 									var ClientID string


### PR DESCRIPTION
## Summary
- allow the teamserver dispatch loop to parse CommandID values encoded as either decimal or hexadecimal strings

## Testing
- go test ./... *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ea9306e4833290671c6b4b1d5c11