### PR TITLE
Normalize headless CommandID parsing

### DIFF
--- a/teamserver/cmd/server/dispatch.go
+++ b/teamserver/cmd/server/dispatch.go
@@ -165,13 +165,16 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 							} else {
 
 								// TODO: move to own function.
-								command, err = strconv.Atoi(val.(string))
+								var parsed int64
+								commandString := strings.TrimSpace(fmt.Sprint(val))
+								parsed, err = strconv.ParseInt(commandString, 0, 32)
 								if err != nil {
 
 									logger.Error("Failed to convert CommandID to integer: " + err.Error())
 									command = 0
 
 								} else {
+									command = int(parsed)
 									*Message = make(map[string]string)
 
 									var ClientID string


### PR DESCRIPTION
## Summary
- trim and normalize CommandID values before parsing to support hex strings from the headless client

## Testing
- go test ./... *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ea9306e4833290671c6b4b1d5c11