### PR TITLE
Fix command parsing bug and guard database setup

### DIFF
--- a/teamserver/cmd/server.go
+++ b/teamserver/cmd/server.go
@@ -35,6 +35,9 @@ var CobraServer = &cobra.Command{
 		}
 
 		Server = server.NewTeamserver(DatabasePath)
+		if Server == nil {
+			return fmt.Errorf("failed to initialize teamserver database")
+		}
 		Server.SetServerFlags(flags)
 
 		logr.LogrInstance = logr.NewLogr(DirPath, LogrPath)

--- a/teamserver/cmd/server/dispatch.go
+++ b/teamserver/cmd/server/dispatch.go
@@ -174,7 +174,6 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 									command = 0
 
 								} else {
-									command = int(parsed)
 									*Message = make(map[string]string)
 
 									var ClientID string

--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +36,11 @@ import (
 )
 
 func NewTeamserver(DatabasePath string) *Teamserver {
+	if err := os.MkdirAll(filepath.Dir(DatabasePath), 0o755); err != nil {
+		logger.Error("Failed to create database directory: " + err.Error())
+		return nil
+	}
+
 	if d, err := db.DatabaseNew(DatabasePath); err != nil {
 		logger.Error("Failed to create a new db: " + err.Error())
 		return nil


### PR DESCRIPTION
## Summary
- remove the stale parsed variable assignment when handling command IDs
- ensure the database directory exists before initialization
- abort command execution if the teamserver failed to initialize

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4f59f825c83328dd2331f95c3e7df