### PR TITLE
Add interactive headless workflows for listeners and demons

### DIFF
--- a/docs/headless-listeners-and-demons.md
+++ b/docs/headless-listeners-and-demons.md
@@ -1,0 +1,164 @@
+# Creating listeners and demons with the headless client
+
+This guide shows how to automate listener provisioning and demon builds over the bundled headless Havoc client. It uses the same WebSocket protocol that the Qt GUI speaks, so you can re-use the Go implementation inside `teamserver/cmd/headless` to script the workflow end-to-end.
+
+## Prerequisites
+
+1. **Build the headless CLI.** Compile the Go module from `teamserver/` so that the `havoc` binary exposes the `headless` subcommand. 【F:teamserver/cmd/headless/headless.go†L70-L139】
+2. **Start the teamserver and connect.** Launch the teamserver, then run the headless client with the operator credentials you configured:
+
+   ```bash
+   cd teamserver
+   go build -o havoc
+   ./havoc headless --host 127.0.0.1 --port 40056 --user operator --password "super-secret"
+   ```
+
+   The flags mirror the Qt login screen: host, port, username, password, and optional TLS verification and prompt controls. 【F:teamserver/cmd/headless/headless.go†L70-L139】
+
+When the connection succeeds the client caches listeners, agents, and chat updates so your automation can react to state changes. 【F:teamserver/cmd/headless/headless.go†L124-L160】【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Guided listener creation from the CLI
+
+Once authenticated you can type `listener-create` in the headless prompt to launch an interactive wizard that seeds every field
+with a hardened HTTPS listener configuration. 【F:teamserver/cmd/headless/headless.go†L575-L655】 Press Enter to keep the defau
+lt or provide a new value before the package is sent to the teamserver. The defaults match the requested profile:
+
+- **Name:** `AS13_Listener`
+- **Protocol:** `Https` (automatically marks the listener as secure)
+- **Bind host / port:** `192.168.2.50:443`
+- **Connect port:** `443`
+- **Hosts:** `192.168.198.128`
+- **Host rotation:** `Round-Robin`
+- **User-Agent:** `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.3
+6`
+- **Proxy:** disabled by default, with additional prompts only when you flip it on
+
+When you accept the prompts the client emits a `Listener.Add` request that mirrors the GUI payload and logs the submission. 【F:t
+eamserver/cmd/headless/headless.go†L657-L691】 The listener immediately appears in `listeners` output once the teamserver ackno
+wledges it. 【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Guided demon builds from the CLI
+
+Use the `demon-create` command to step through the stageless build flow without touching the Qt dialogs. 【F:teamserver/cmd/head
+less/headless.go†L693-L770】 The wizard pre-populates the demon request with the provided agent settings, letting you tweak any 
+field before the package is dispatched:
+
+- **Listener:** `AS13_Listener`
+- **Agent / Format / Arch:** Demon, `Windows Shellcode`, `x64`
+- **Sleep / Jitter:** 5 seconds with 35% jitter
+- **Sleep technique:** `Ekko`, **sleep jump gadget:** `None`
+- **Stack duplication:** enabled
+- **Proxy loading:** `RtlCreateTimer`
+- **Indirect syscall:** enabled
+- **Amsi/Etw patch:** `Hardware breakpoints`
+- **Injection defaults:** `Native/Syscall` allocation and execution with Notepad spawn stubs for x64/x86
+
+After confirmation the client marshals the JSON config, submits `Gate.Stageless`, and announces the build request on the log str
+eam. 【F:teamserver/cmd/headless/headless.go†L745-L770】 Monitor the console (or run with `--no-prompt`) to capture the base64 pa
+yload that follows. 【F:teamserver/cmd/headless/headless.go†L70-L108】【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Creating listeners programmatically
+
+The GUI collects listener parameters (name, protocol, bind address, host rotation, headers, URIs, and proxy settings) and serialises them into the `Listener.Add` payload. 【F:client/src/UserInterface/Dialogs/Listener.cc†L618-L698】 The teamserver stores the config and immediately broadcasts a summary package back to every session. 【F:teamserver/cmd/server/listener.go†L220-L333】
+
+Automation can reuse the headless client's `submitListenerAdd` helper directly—either by feeding the wizard defaults from `defaultListenerConfig()` or by composing a map manually: 【F:teamserver/cmd/headless/headless.go†L575-L691】
+
+```go
+cfg := defaultListenerConfig()
+cfg.Name = "training-listener"
+cfg.Hosts = "c2.company.tld"
+
+info := map[string]any{
+    "Name":          cfg.Name,
+    "Protocol":      cfg.Protocol,
+    "Status":        "online",
+    "Secure":        "true",
+    "Hosts":         cfg.Hosts,
+    "HostBind":      cfg.HostBind,
+    "HostRotation":  cfg.HostRotation,
+    "PortBind":      cfg.PortBind,
+    "PortConn":      cfg.PortConn,
+    "Headers":       cfg.Headers,
+    "Uris":          cfg.Uris,
+    "UserAgent":     cfg.UserAgent,
+    "HostHeader":    cfg.HostHeader,
+    "Proxy Enabled": strconv.FormatBool(cfg.ProxyEnabled),
+}
+
+if err := client.submitListenerAdd(info); err != nil {
+    log.Fatal(err)
+}
+```
+
+When the teamserver acknowledges the listener, the reader loop updates `c.state.listeners`, so calling the `listeners` command or `snapshotListeners()` will show the new handler. 【F:teamserver/cmd/headless/headless.go†L252-L320】【F:teamserver/cmd/headless/headless.go†L666-L673】
+
+> **Tip:** If you have a JSON template for the listener configuration, load it into the `info` map before sending. The server normalises booleans and host lists the same way it does for the GUI, so you only need to supply the keys you care about. 【F:teamserver/cmd/server/listener.go†L228-L333】
+
+## Building demons (stageless payloads)
+
+The payload dialog in the GUI submits a `Gate.Stageless` request that contains the agent type, listener name, architecture, output format, and JSON-encoded demon configuration. 【F:client/src/UserInterface/Dialogs/Payload.cc†L222-L248】 The dispatcher unmarshals this request, stitches the payload together, and replies with a base64-encoded artifact when the build succeeds. 【F:teamserver/cmd/server/dispatch.go†L821-L925】【F:teamserver/pkg/events/gate.go†L12-L27】
+
+Headless automations can replicate `demon-create` by cloning the defaults from `defaultDemonBuildConfig()` and then invoking `sendPackage` with the assembled JSON payload. 【F:teamserver/cmd/headless/headless.go†L605-L770】 For example:
+
+```go
+cfg := defaultDemonBuildConfig()
+cfg.Listener = "AS13_Listener"
+cfg.Format = "Windows Shellcode"
+
+config := map[string]any{
+    "Sleep":             cfg.Sleep,
+    "Jitter":            cfg.Jitter,
+    "Indirect Syscall":  cfg.IndirectSyscall,
+    "Stack Duplication": cfg.StackDuplication,
+    "Sleep Technique":   cfg.SleepTechnique,
+    "Sleep Jmp Gadget":  cfg.SleepJmpGadget,
+    "Proxy Loading":     cfg.ProxyLoading,
+    "Amsi/Etw Patch":    cfg.AmsiEtwPatch,
+    "Injection": map[string]any{
+        "Alloc":   cfg.InjectionAlloc,
+        "Execute": cfg.InjectionExecute,
+        "Spawn64": cfg.InjectionSpawn64,
+        "Spawn32": cfg.InjectionSpawn32,
+    },
+}
+
+configJSON, _ := json.Marshal(config)
+pk := packager.Package{
+    Head: packager.Head{
+        Event:   packager.Type.Gate.Type,
+        User:    client.username,
+        Time:    time.Now().Format("02/01/2006 15:04:05"),
+        OneTime: "true",
+    },
+    Body: packager.Body{
+        SubEvent: packager.Type.Gate.Stageless,
+        Info: map[string]any{
+            "AgentType": "Demon",
+            "Listener":  cfg.Listener,
+            "Arch":      cfg.Arch,
+            "Format":    cfg.Format,
+            "Config":    string(configJSON),
+        },
+    },
+}
+
+if err := client.sendPackage(pk); err != nil {
+    log.Fatal(err)
+}
+```
+
+The dispatcher emits console events that stream build progress, followed by a `Gate.Stageless` response whose `PayloadArray` field contains the base64 payload bytes. Persist the returned data under a meaningful filename (for example `demon.x64.bin` for stageless shellcode) and deploy it however you normally would.
+
+Because the headless client already logs gate events, you can keep it in interactive mode to watch the build output, or run with `--no-prompt` and process the responses programmatically inside your automation. 【F:teamserver/cmd/headless/headless.go†L70-L108】【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Putting it together
+
+A minimal automation loop looks like this:
+
+1. Dial the teamserver with `newHeadlessClient`, supplying credentials and TLS options. 【F:teamserver/cmd/headless/headless.go†L88-L139】【F:teamserver/cmd/headless/headless.go†L168-L220】
+2. Run `listener-create` (or call `submitListenerAdd` from your automation) after authentication to provision the C2 endpoint.
+3. Wait for the listener summary to show `Status == Online` via `snapshotListeners()`.
+4. Trigger `demon-create` (or post a `Gate.Stageless` package) with the listener name, architecture, and format you need.
+5. Save the decoded payload returned in the next `Gate.Stageless` package.
+
+With these building blocks you can script full operator workflows—spinning up listeners, generating new demons, and queuing tasks—without ever opening the Qt GUI.

--- a/teamserver/cmd/headless/headless.go
+++ b/teamserver/cmd/headless/headless.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/url"
 	"os"
@@ -159,6 +160,44 @@ type chatMessage struct {
 	Time    string
 	User    string
 	Message string
+}
+
+type listenerConfig struct {
+	Name          string
+	Protocol      string
+	HostBind      string
+	PortBind      string
+	PortConn      string
+	Hosts         string
+	HostRotation  string
+	Headers       string
+	Uris          string
+	UserAgent     string
+	HostHeader    string
+	ProxyEnabled  bool
+	ProxyType     string
+	ProxyHost     string
+	ProxyPort     string
+	ProxyUsername string
+	ProxyPassword string
+}
+
+type demonBuildConfig struct {
+	Listener         string
+	Arch             string
+	Format           string
+	Sleep            int
+	Jitter           int
+	IndirectSyscall  bool
+	StackDuplication bool
+	SleepTechnique   string
+	SleepJmpGadget   string
+	ProxyLoading     string
+	AmsiEtwPatch     string
+	InjectionAlloc   string
+	InjectionExecute string
+	InjectionSpawn64 string
+	InjectionSpawn32 string
 }
 
 func newHeadlessClient(host string, port int, user, password string, insecure bool) (*headlessClient, error) {
@@ -409,14 +448,18 @@ func (c *headlessClient) handleChat(pk packager.Package) {
 
 func (c *headlessClient) interactive(ctx context.Context, cancel context.CancelFunc) error {
 	fmt.Println("Headless Havoc client ready. Type 'help' for a list of commands.")
-	scanner := bufio.NewScanner(os.Stdin)
+	reader := bufio.NewReader(os.Stdin)
 	for {
 		fmt.Print("> ")
-		if !scanner.Scan() {
-			return scanner.Err()
+		line, err := readLine(reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
 		}
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
 			continue
 		}
 
@@ -426,7 +469,7 @@ func (c *headlessClient) interactive(ctx context.Context, cancel context.CancelF
 		default:
 		}
 
-		fields := strings.Fields(line)
+		fields := strings.Fields(trimmed)
 		cmd := strings.ToLower(fields[0])
 		args := fields[1:]
 
@@ -435,8 +478,20 @@ func (c *headlessClient) interactive(ctx context.Context, cancel context.CancelF
 			c.printHelp()
 		case "listeners":
 			c.printListeners()
+		case "listener-create":
+			if err := c.handleListenerCreate(ctx, reader); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					fmt.Printf("failed to create listener: %v\n", err)
+				}
+			}
 		case "agents":
 			c.printAgents()
+		case "demon-create":
+			if err := c.handleDemonCreate(ctx, reader); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					fmt.Printf("failed to create demon: %v\n", err)
+				}
+			}
 		case "chatlog":
 			c.printChat()
 		case "chat":
@@ -444,12 +499,12 @@ func (c *headlessClient) interactive(ctx context.Context, cancel context.CancelF
 				fmt.Println("usage: chat <message>")
 				continue
 			}
-			message := strings.TrimSpace(line[len(fields[0]):])
+			message := strings.TrimSpace(trimmed[len(fields[0]):])
 			if err := c.sendChat(message); err != nil {
 				fmt.Printf("failed to send chat message: %v\n", err)
 			}
 		case "task":
-			if err := c.handleTaskCommand(line, args); err != nil {
+			if err := c.handleTaskCommand(trimmed, args); err != nil {
 				fmt.Printf("failed to send task: %v\n", err)
 			}
 		case "mark":
@@ -473,7 +528,9 @@ func (c *headlessClient) printHelp() {
 	fmt.Println(`Available commands:
   help                Show this help message
   listeners           Display listeners known to the teamserver
+  listener-create     Launch an interactive wizard to create a listener
   agents              Display active agents
+  demon-create        Launch an interactive wizard to request a stageless demon
   chatlog             Show the recent chat messages
   chat <message>      Send a chat message to all operators
   task <agent> <command-id> [one-time] [CommandLine text] [key=value ...]
@@ -531,6 +588,250 @@ func (c *headlessClient) printChat() {
 	}
 }
 
+func defaultListenerConfig() listenerConfig {
+	return listenerConfig{
+		Name:         "AS13_Listener",
+		Protocol:     "Https",
+		HostBind:     "192.168.2.50",
+		PortBind:     "443",
+		PortConn:     "443",
+		Hosts:        "192.168.198.128",
+		HostRotation: "Round-Robin",
+		UserAgent:    "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
+	}
+}
+
+func defaultDemonBuildConfig() demonBuildConfig {
+	return demonBuildConfig{
+		Listener:         "AS13_Listener",
+		Arch:             "x64",
+		Format:           "Windows Shellcode",
+		Sleep:            5,
+		Jitter:           35,
+		IndirectSyscall:  true,
+		StackDuplication: true,
+		SleepTechnique:   "Ekko",
+		SleepJmpGadget:   "None",
+		ProxyLoading:     "RtlCreateTimer",
+		AmsiEtwPatch:     "Hardware breakpoints",
+		InjectionAlloc:   "Native/Syscall",
+		InjectionExecute: "Native/Syscall",
+		InjectionSpawn64: "C:\\Windows\\System32\\notepad.exe",
+		InjectionSpawn32: "C:\\Windows\\SysWOW64\\notepad.exe",
+	}
+}
+
+func (c *headlessClient) handleListenerCreate(ctx context.Context, reader *bufio.Reader) error {
+	cfg := defaultListenerConfig()
+	fmt.Println("Configure listener settings (press Enter to accept the default in brackets).")
+
+	var err error
+	if cfg.Name, err = promptString(ctx, reader, "Name", cfg.Name); err != nil {
+		return err
+	}
+	protocolChoices := []string{"Https", "Http"}
+	if cfg.Protocol, err = promptChoice(ctx, reader, "Protocol", cfg.Protocol, protocolChoices); err != nil {
+		return err
+	}
+	if cfg.HostBind, err = promptString(ctx, reader, "Bind Host", cfg.HostBind); err != nil {
+		return err
+	}
+	if cfg.PortBind, err = promptString(ctx, reader, "Bind Port", cfg.PortBind); err != nil {
+		return err
+	}
+	if cfg.PortConn, err = promptString(ctx, reader, "Connect Port", cfg.PortConn); err != nil {
+		return err
+	}
+	if cfg.Hosts, err = promptString(ctx, reader, "Hosts (comma separated)", cfg.Hosts); err != nil {
+		return err
+	}
+	if cfg.HostRotation, err = promptString(ctx, reader, "Host Rotation", cfg.HostRotation); err != nil {
+		return err
+	}
+	if cfg.Uris, err = promptString(ctx, reader, "URIs (comma separated)", cfg.Uris); err != nil {
+		return err
+	}
+	if cfg.Headers, err = promptString(ctx, reader, "Headers (comma separated)", cfg.Headers); err != nil {
+		return err
+	}
+	if cfg.UserAgent, err = promptString(ctx, reader, "User-Agent", cfg.UserAgent); err != nil {
+		return err
+	}
+	if cfg.HostHeader, err = promptString(ctx, reader, "Host Header", cfg.HostHeader); err != nil {
+		return err
+	}
+	if cfg.ProxyEnabled, err = promptBool(ctx, reader, "Proxy Enabled", cfg.ProxyEnabled); err != nil {
+		return err
+	}
+	if cfg.ProxyEnabled {
+		if cfg.ProxyType, err = promptString(ctx, reader, "Proxy Type", cfg.ProxyType); err != nil {
+			return err
+		}
+		if cfg.ProxyHost, err = promptString(ctx, reader, "Proxy Host", cfg.ProxyHost); err != nil {
+			return err
+		}
+		if cfg.ProxyPort, err = promptString(ctx, reader, "Proxy Port", cfg.ProxyPort); err != nil {
+			return err
+		}
+		if cfg.ProxyUsername, err = promptString(ctx, reader, "Proxy Username", cfg.ProxyUsername); err != nil {
+			return err
+		}
+		if cfg.ProxyPassword, err = promptString(ctx, reader, "Proxy Password", cfg.ProxyPassword); err != nil {
+			return err
+		}
+	}
+
+	info := map[string]any{
+		"Name":          cfg.Name,
+		"Protocol":      cfg.Protocol,
+		"Status":        "online",
+		"Secure":        "false",
+		"Hosts":         cfg.Hosts,
+		"HostBind":      cfg.HostBind,
+		"HostRotation":  cfg.HostRotation,
+		"PortBind":      cfg.PortBind,
+		"PortConn":      cfg.PortConn,
+		"Headers":       cfg.Headers,
+		"Uris":          cfg.Uris,
+		"UserAgent":     cfg.UserAgent,
+		"HostHeader":    cfg.HostHeader,
+		"Proxy Enabled": strconv.FormatBool(cfg.ProxyEnabled),
+	}
+
+	if strings.EqualFold(cfg.Protocol, "https") {
+		info["Secure"] = "true"
+	}
+
+	if cfg.ProxyEnabled {
+		info["Proxy Type"] = cfg.ProxyType
+		info["Proxy Host"] = cfg.ProxyHost
+		info["Proxy Port"] = cfg.ProxyPort
+		info["Proxy Username"] = cfg.ProxyUsername
+		info["Proxy Password"] = cfg.ProxyPassword
+	}
+
+	if err := c.submitListenerAdd(info); err != nil {
+		return err
+	}
+	c.printf("submitted listener creation request for %s", cfg.Name)
+	return nil
+}
+
+func (c *headlessClient) handleDemonCreate(ctx context.Context, reader *bufio.Reader) error {
+	cfg := defaultDemonBuildConfig()
+	fmt.Println("Configure demon build (press Enter to accept the default in brackets).")
+
+	var err error
+	listeners := c.state.snapshotListeners()
+	if len(listeners) > 0 {
+		fmt.Print("Known listeners: ")
+		names := make([]string, 0, len(listeners))
+		for _, l := range listeners {
+			names = append(names, l.Name)
+		}
+		fmt.Println(strings.Join(names, ", "))
+	}
+
+	if cfg.Listener, err = promptString(ctx, reader, "Listener", cfg.Listener); err != nil {
+		return err
+	}
+	if cfg.Arch, err = promptChoice(ctx, reader, "Architecture", cfg.Arch, []string{"x64", "x86"}); err != nil {
+		return err
+	}
+	formatChoices := []string{"Windows Exe", "Windows Service Exe", "Windows DLL", "Windows Shellcode"}
+	if cfg.Format, err = promptChoice(ctx, reader, "Format", cfg.Format, formatChoices); err != nil {
+		return err
+	}
+	if cfg.Sleep, err = promptInt(ctx, reader, "Sleep (seconds)", cfg.Sleep); err != nil {
+		return err
+	}
+	if cfg.Jitter, err = promptInt(ctx, reader, "Jitter (0-100)", cfg.Jitter); err != nil {
+		return err
+	}
+	if cfg.IndirectSyscall, err = promptBool(ctx, reader, "Indirect Syscall", cfg.IndirectSyscall); err != nil {
+		return err
+	}
+	if cfg.StackDuplication, err = promptBool(ctx, reader, "Stack Duplication", cfg.StackDuplication); err != nil {
+		return err
+	}
+	sleepChoices := []string{"WaitForSingleObjectEx", "Foliage", "Ekko", "Zilean"}
+	if cfg.SleepTechnique, err = promptChoice(ctx, reader, "Sleep Technique", cfg.SleepTechnique, sleepChoices); err != nil {
+		return err
+	}
+	gadgetChoices := []string{"None", "jmp rax", "jmp rbx"}
+	if cfg.SleepJmpGadget, err = promptChoice(ctx, reader, "Sleep Jmp Gadget", cfg.SleepJmpGadget, gadgetChoices); err != nil {
+		return err
+	}
+	proxyChoices := []string{"None (LdrLoadDll)", "RtlRegisterWait", "RtlCreateTimer", "RtlQueueWorkItem"}
+	if cfg.ProxyLoading, err = promptChoice(ctx, reader, "Proxy Loading", cfg.ProxyLoading, proxyChoices); err != nil {
+		return err
+	}
+	amsiChoices := []string{"None", "Hardware breakpoints"}
+	if cfg.AmsiEtwPatch, err = promptChoice(ctx, reader, "Amsi/Etw Patch", cfg.AmsiEtwPatch, amsiChoices); err != nil {
+		return err
+	}
+	allocChoices := []string{"Win32", "Native/Syscall"}
+	if cfg.InjectionAlloc, err = promptChoice(ctx, reader, "Injection Alloc", cfg.InjectionAlloc, allocChoices); err != nil {
+		return err
+	}
+	if cfg.InjectionExecute, err = promptChoice(ctx, reader, "Injection Execute", cfg.InjectionExecute, allocChoices); err != nil {
+		return err
+	}
+	if cfg.InjectionSpawn64, err = promptString(ctx, reader, "Injection Spawn64", cfg.InjectionSpawn64); err != nil {
+		return err
+	}
+	if cfg.InjectionSpawn32, err = promptString(ctx, reader, "Injection Spawn32", cfg.InjectionSpawn32); err != nil {
+		return err
+	}
+
+	config := map[string]any{
+		"Sleep":             cfg.Sleep,
+		"Jitter":            cfg.Jitter,
+		"Indirect Syscall":  cfg.IndirectSyscall,
+		"Stack Duplication": cfg.StackDuplication,
+		"Sleep Technique":   cfg.SleepTechnique,
+		"Sleep Jmp Gadget":  cfg.SleepJmpGadget,
+		"Proxy Loading":     cfg.ProxyLoading,
+		"Amsi/Etw Patch":    cfg.AmsiEtwPatch,
+		"Injection": map[string]any{
+			"Alloc":   cfg.InjectionAlloc,
+			"Execute": cfg.InjectionExecute,
+			"Spawn64": cfg.InjectionSpawn64,
+			"Spawn32": cfg.InjectionSpawn32,
+		},
+	}
+
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	pk := packager.Package{
+		Head: packager.Head{
+			Event:   packager.Type.Gate.Type,
+			User:    c.username,
+			Time:    time.Now().Format("02/01/2006 15:04:05"),
+			OneTime: "true",
+		},
+		Body: packager.Body{
+			SubEvent: packager.Type.Gate.Stageless,
+			Info: map[string]any{
+				"AgentType": "Demon",
+				"Listener":  cfg.Listener,
+				"Arch":      cfg.Arch,
+				"Format":    cfg.Format,
+				"Config":    string(configJSON),
+			},
+		},
+	}
+
+	if err := c.sendPackage(pk); err != nil {
+		return err
+	}
+	c.printf("requested stageless %s demon for listener %s", cfg.Arch, cfg.Listener)
+	return nil
+}
+
 func (c *headlessClient) sendChat(message string) error {
 	if strings.TrimSpace(message) == "" {
 		return errors.New("message cannot be empty")
@@ -546,6 +847,21 @@ func (c *headlessClient) sendChat(message string) error {
 		},
 		Body: packager.Body{
 			SubEvent: packager.Type.Chat.NewMessage,
+			Info:     info,
+		},
+	}
+	return c.sendPackage(pk)
+}
+
+func (c *headlessClient) submitListenerAdd(info map[string]any) error {
+	pk := packager.Package{
+		Head: packager.Head{
+			Event: packager.Type.Listener.Type,
+			User:  c.username,
+			Time:  time.Now().Format("02/01/2006 15:04:05"),
+		},
+		Body: packager.Body{
+			SubEvent: packager.Type.Listener.Add,
 			Info:     info,
 		},
 	}
@@ -724,6 +1040,113 @@ func mapToStringMap(in map[string]any) map[string]string {
 		}
 	}
 	return out
+}
+
+func readLine(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			if len(line) == 0 {
+				return "", io.EOF
+			}
+			return strings.TrimRight(line, "\r\n"), nil
+		}
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func promptString(ctx context.Context, reader *bufio.Reader, label, def string) (string, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		fmt.Printf("%s [%s]: ", label, def)
+		value, err := readLine(reader)
+		if err != nil {
+			return "", err
+		}
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return def, nil
+		}
+		return trimmed, nil
+	}
+}
+
+func promptChoice(ctx context.Context, reader *bufio.Reader, label, def string, choices []string) (string, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		fmt.Printf("%s [%s]: ", label, def)
+		value, err := readLine(reader)
+		if err != nil {
+			return "", err
+		}
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return def, nil
+		}
+		for _, choice := range choices {
+			if strings.EqualFold(trimmed, choice) {
+				return choice, nil
+			}
+		}
+		fmt.Printf("invalid value. valid options: %s\n", strings.Join(choices, ", "))
+	}
+}
+
+func promptBool(ctx context.Context, reader *bufio.Reader, label string, def bool) (bool, error) {
+	defDisplay := "n"
+	if def {
+		defDisplay = "y"
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		fmt.Printf("%s [%s]: ", label, defDisplay)
+		value, err := readLine(reader)
+		if err != nil {
+			return false, err
+		}
+		trimmed := strings.TrimSpace(strings.ToLower(value))
+		if trimmed == "" {
+			return def, nil
+		}
+		switch trimmed {
+		case "y", "yes", "true", "1":
+			return true, nil
+		case "n", "no", "false", "0":
+			return false, nil
+		default:
+			fmt.Println("please answer with y/n")
+		}
+	}
+}
+
+func promptInt(ctx context.Context, reader *bufio.Reader, label string, def int) (int, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		fmt.Printf("%s [%d]: ", label, def)
+		value, err := readLine(reader)
+		if err != nil {
+			return 0, err
+		}
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return def, nil
+		}
+		n, convErr := strconv.Atoi(trimmed)
+		if convErr != nil {
+			fmt.Println("please enter a valid number")
+			continue
+		}
+		return n, nil
+	}
 }
 
 func stringValue(m map[string]any, key string) string {


### PR DESCRIPTION
## Summary
- add interactive listener-create and demon-create commands to the headless client with configurable defaults
- expose reusable helpers for default listener/demon settings and prompt handling to support scripted automation
- document the new CLI workflows and update examples for building listeners and stageless payloads

## Testing
- go build ./cmd/headless

------
https://chatgpt.com/codex/tasks/task_e_68e505ff5c8083328913fd16ebadf5ca