### PR TITLE
Handle gate payload errors in headless client

### DIFF
--- a/docs/headless-listeners-and-demons.md
+++ b/docs/headless-listeners-and-demons.md
@@ -1,0 +1,164 @@
+# Creating listeners and demons with the headless client
+
+This guide shows how to automate listener provisioning and demon builds over the bundled headless Havoc client. It uses the same WebSocket protocol that the Qt GUI speaks, so you can re-use the Go implementation inside `teamserver/cmd/headless` to script the workflow end-to-end.
+
+## Prerequisites
+
+1. **Build the headless CLI.** Compile the Go module from `teamserver/` so that the `havoc` binary exposes the `headless` subcommand. 【F:teamserver/cmd/headless/headless.go†L70-L139】
+2. **Start the teamserver and connect.** Launch the teamserver, then run the headless client with the operator credentials you configured:
+
+   ```bash
+   cd teamserver
+   go build -o havoc
+   ./havoc headless --host 127.0.0.1 --port 40056 --user operator --password "super-secret"
+   ```
+
+   The flags mirror the Qt login screen: host, port, username, password, and optional TLS verification and prompt controls. 【F:teamserver/cmd/headless/headless.go†L70-L139】
+
+When the connection succeeds the client caches listeners, agents, and chat updates so your automation can react to state changes. 【F:teamserver/cmd/headless/headless.go†L124-L160】【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Guided listener creation from the CLI
+
+Once authenticated you can type `listener-create` in the headless prompt to launch an interactive wizard that seeds every field
+with a hardened HTTPS listener configuration. 【F:teamserver/cmd/headless/headless.go†L575-L655】 Press Enter to keep the defau
+lt or provide a new value before the package is sent to the teamserver. The defaults match the requested profile:
+
+- **Name:** `AS13_Listener`
+- **Protocol:** `Https` (automatically marks the listener as secure)
+- **Bind host / port:** `192.168.2.50:443`
+- **Connect port:** `443`
+- **Hosts:** `192.168.198.128`
+- **Host rotation:** `Round-Robin`
+- **User-Agent:** `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.3
+6`
+- **Proxy:** disabled by default, with additional prompts only when you flip it on
+
+When you accept the prompts the client emits a `Listener.Add` request that mirrors the GUI payload and logs the submission. 【F:t
+eamserver/cmd/headless/headless.go†L657-L691】 The listener immediately appears in `listeners` output once the teamserver ackno
+wledges it. 【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Guided demon builds from the CLI
+
+Use the `demon-create` command to step through the stageless build flow without touching the Qt dialogs. 【F:teamserver/cmd/head
+less/headless.go†L693-L770】 The wizard pre-populates the demon request with the provided agent settings, letting you tweak any 
+field before the package is dispatched:
+
+- **Listener:** `AS13_Listener`
+- **Agent / Format / Arch:** Demon, `Windows Shellcode`, `x64`
+- **Sleep / Jitter:** 5 seconds with 35% jitter
+- **Sleep technique:** `Ekko`, **sleep jump gadget:** `None`
+- **Stack duplication:** enabled
+- **Proxy loading:** `RtlCreateTimer`
+- **Indirect syscall:** enabled
+- **Amsi/Etw patch:** `Hardware breakpoints`
+- **Injection defaults:** `Native/Syscall` allocation and execution with Notepad spawn stubs for x64/x86
+
+After confirmation the client marshals the JSON config, submits `Gate.Stageless`, and announces the build request on the log str
+eam. 【F:teamserver/cmd/headless/headless.go†L745-L770】 Monitor the console (or run with `--no-prompt`) to capture the base64 pa
+yload that follows. 【F:teamserver/cmd/headless/headless.go†L70-L108】【F:teamserver/cmd/headless/headless.go†L252-L320】
+
+## Creating listeners programmatically
+
+The GUI collects listener parameters (name, protocol, bind address, host rotation, headers, URIs, and proxy settings) and serialises them into the `Listener.Add` payload. 【F:client/src/UserInterface/Dialogs/Listener.cc†L618-L698】 The teamserver stores the config and immediately broadcasts a summary package back to every session. 【F:teamserver/cmd/server/listener.go†L220-L333】
+
+Automation can reuse the headless client's `submitListenerAdd` helper directly—either by feeding the wizard defaults from `defaultListenerConfig()` or by composing a map manually: 【F:teamserver/cmd/headless/headless.go†L575-L691】
+
+```go
+cfg := defaultListenerConfig()
+cfg.Name = "training-listener"
+cfg.Hosts = "c2.company.tld"
+
+info := map[string]any{
+    "Name":          cfg.Name,
+    "Protocol":      cfg.Protocol,
+    "Status":        "online",
+    "Secure":        "true",
+    "Hosts":         cfg.Hosts,
+    "HostBind":      cfg.HostBind,
+    "HostRotation":  cfg.HostRotation,
+    "PortBind":      cfg.PortBind,
+    "PortConn":      cfg.PortConn,
+    "Headers":       cfg.Headers,
+    "Uris":          cfg.Uris,
+    "UserAgent":     cfg.UserAgent,
+    "HostHeader":    cfg.HostHeader,
+    "Proxy Enabled": strconv.FormatBool(cfg.ProxyEnabled),
+}
+
+if err := client.submitListenerAdd(info); err != nil {
+    log.Fatal(err)
+}
+```
+
+When the teamserver acknowledges the listener, the reader loop updates `c.state.listeners`, so calling the `listeners` command or `snapshotListeners()` will show the new handler. 【F:teamserver/cmd/headless/headless.go†L252-L320】【F:teamserver/cmd/headless/headless.go†L666-L673】
+
+> **Tip:** If you have a JSON template for the listener configuration, load it into the `info` map before sending. The server normalises booleans and host lists the same way it does for the GUI, so you only need to supply the keys you care about. 【F:teamserver/cmd/server/listener.go†L228-L333】
+
+## Building demons (stageless payloads)
+
+The payload dialog in the GUI submits a `Gate.Stageless` request that contains the agent type, listener name, architecture, output format, and JSON-encoded demon configuration. 【F:client/src/UserInterface/Dialogs/Payload.cc†L222-L248】 The dispatcher unmarshals this request, stitches the payload together, and replies with a base64-encoded artifact when the build succeeds. 【F:teamserver/cmd/server/dispatch.go†L821-L925】【F:teamserver/pkg/events/gate.go†L12-L27】
+
+Headless automations can replicate `demon-create` by cloning the defaults from `defaultDemonBuildConfig()` and then invoking `sendPackage` with the assembled JSON payload. 【F:teamserver/cmd/headless/headless.go†L605-L770】 For example:
+
+```go
+cfg := defaultDemonBuildConfig()
+cfg.Listener = "AS13_Listener"
+cfg.Format = "Windows Shellcode"
+
+config := map[string]any{
+    "Sleep":             cfg.Sleep,
+    "Jitter":            cfg.Jitter,
+    "Indirect Syscall":  cfg.IndirectSyscall,
+    "Stack Duplication": cfg.StackDuplication,
+    "Sleep Technique":   cfg.SleepTechnique,
+    "Sleep Jmp Gadget":  cfg.SleepJmpGadget,
+    "Proxy Loading":     cfg.ProxyLoading,
+    "Amsi/Etw Patch":    cfg.AmsiEtwPatch,
+    "Injection": map[string]any{
+        "Alloc":   cfg.InjectionAlloc,
+        "Execute": cfg.InjectionExecute,
+        "Spawn64": cfg.InjectionSpawn64,
+        "Spawn32": cfg.InjectionSpawn32,
+    },
+}
+
+configJSON, _ := json.Marshal(config)
+pk := packager.Package{
+    Head: packager.Head{
+        Event:   packager.Type.Gate.Type,
+        User:    client.username,
+        Time:    time.Now().Format("02/01/2006 15:04:05"),
+        OneTime: "true",
+    },
+    Body: packager.Body{
+        SubEvent: packager.Type.Gate.Stageless,
+        Info: map[string]any{
+            "AgentType": "Demon",
+            "Listener":  cfg.Listener,
+            "Arch":      cfg.Arch,
+            "Format":    cfg.Format,
+            "Config":    string(configJSON),
+        },
+    },
+}
+
+if err := client.sendPackage(pk); err != nil {
+    log.Fatal(err)
+}
+```
+
+The dispatcher emits console events that stream build progress, followed by a `Gate.Stageless` response whose `PayloadArray` field contains the base64 payload bytes. The headless client now prints those console messages and automatically writes the decoded payload to disk using the server-provided filename (it appends a numeric suffix when the file already exists).【F:teamserver/cmd/headless/headless.go†L429-L476】 Check the prompt output for the exact save path—for example `demon.x64.bin` for stageless shellcode—and deploy it however you normally would.
+
+Because the headless client captures the gate stream, you can keep it in interactive mode to watch the build output, or run with `--no-prompt` and process the responses programmatically inside your automation.【F:teamserver/cmd/headless/headless.go†L70-L108】【F:teamserver/cmd/headless/headless.go†L429-L476】
+
+## Putting it together
+
+A minimal automation loop looks like this:
+
+1. Dial the teamserver with `newHeadlessClient`, supplying credentials and TLS options. 【F:teamserver/cmd/headless/headless.go†L88-L139】【F:teamserver/cmd/headless/headless.go†L168-L220】
+2. Run `listener-create` (or call `submitListenerAdd` from your automation) after authentication to provision the C2 endpoint.
+3. Wait for the listener summary to show `Status == Online` via `snapshotListeners()`.
+4. Trigger `demon-create` (or post a `Gate.Stageless` package) with the listener name, architecture, and format you need.
+5. Save the decoded payload returned in the next `Gate.Stageless` package.
+
+With these building blocks you can script full operator workflows—spinning up listeners, generating new demons, and queuing tasks—without ever opening the Qt GUI.

--- a/teamserver/pkg/utils/utils.go
+++ b/teamserver/pkg/utils/utils.go
@@ -1,118 +1,142 @@
 package utils
 
 import (
-    "encoding/base64"
-    "encoding/binary"
-    "unicode/utf16"
-    "fmt"
-    "math/rand"
-    "os"
-    "strconv"
-    "strings"
-    "time"
-    "unsafe"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf16"
+	"unsafe"
 
-    "Havoc/pkg/logger"
+	"Havoc/pkg/logger"
 )
 
 const letterBytes = "abcdef0123456789"
 const (
-    letterIdxBits = 4
-    letterIdxMask = 1<<letterIdxBits - 1
-    letterIdxMax  = 63 / letterIdxBits
+	letterIdxBits = 4
+	letterIdxMask = 1<<letterIdxBits - 1
+	letterIdxMax  = 63 / letterIdxBits
 )
 
 func UTF16BytesToString(b []byte) string {
-    size := (len(b) - 2) / 2
-    utf := make([]uint16, size)
-    for i := 0; i < size; i += 1 {
-        utf[i] = binary.LittleEndian.Uint16(b[i*2:])
-    }
-    return string(utf16.Decode(utf))
+	size := (len(b) - 2) / 2
+	utf := make([]uint16, size)
+	for i := 0; i < size; i += 1 {
+		utf[i] = binary.LittleEndian.Uint16(b[i*2:])
+	}
+	return string(utf16.Decode(utf))
 }
 
 func GenerateID(n int) string {
-    var src = rand.NewSource(time.Now().UnixNano())
-    b := make([]byte, n)
-    // A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
-    for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
-        if remain == 0 {
-            cache, remain = src.Int63(), letterIdxMax
-        }
-        if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-            b[i] = letterBytes[idx]
-            i--
-        }
-        cache >>= letterIdxBits
-        remain--
-    }
+	var src = rand.NewSource(time.Now().UnixNano())
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
 
-    return string(b)
+	return string(b)
 }
 
 func GenerateString(min int, max int) string {
-    rand.Seed(time.Now().UnixNano())
-    length := min + rand.Intn(max - min + 1)
-    var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    b := make([]rune, length)
-    for i := range b {
-        b[i] = letterRunes[rand.Intn(len(letterRunes))]
-    }
+	rand.Seed(time.Now().UnixNano())
+	length := min + rand.Intn(max-min+1)
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
 
-    return string(b)
+	return string(b)
 }
 
 func EncodeCommand(x string) string {
-    encodedCMD := base64.StdEncoding.EncodeToString([]byte(x))
-    return encodedCMD
+	encodedCMD := base64.StdEncoding.EncodeToString([]byte(x))
+	return encodedCMD
 }
 
 func IP2Inet(ipaddr string) uint32 {
-    var (
-        ip                 = strings.Split(ipaddr, ".")
-        ip1, ip2, ip3, ip4 uint64
-        ret                uint32
-    )
-    ip1, _ = strconv.ParseUint(ip[0], 10, 8)
-    ip2, _ = strconv.ParseUint(ip[1], 10, 8)
-    ip3, _ = strconv.ParseUint(ip[2], 10, 8)
-    ip4, _ = strconv.ParseUint(ip[3], 10, 8)
-    ret = uint32(ip4)<<24 + uint32(ip3)<<16 + uint32(ip2)<<8 + uint32(ip1)
-    return ret
+	var (
+		ip                 = strings.Split(ipaddr, ".")
+		ip1, ip2, ip3, ip4 uint64
+		ret                uint32
+	)
+	ip1, _ = strconv.ParseUint(ip[0], 10, 8)
+	ip2, _ = strconv.ParseUint(ip[1], 10, 8)
+	ip3, _ = strconv.ParseUint(ip[2], 10, 8)
+	ip4, _ = strconv.ParseUint(ip[3], 10, 8)
+	ret = uint32(ip4)<<24 + uint32(ip3)<<16 + uint32(ip2)<<8 + uint32(ip1)
+	return ret
 }
 
 func Port2Htons(port uint16) uint16 {
-    b := make([]byte, 2)
-    binary.BigEndian.PutUint16(b, port)
-    return *(*uint16)(unsafe.Pointer(&b[0]))
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, port)
+	return *(*uint16)(unsafe.Pointer(&b[0]))
 }
 
 func ByteCountSI(b int64) string {
-    const unit = 1000
-    if b < unit {
-        return fmt.Sprintf("%d B", b)
-    }
-    div, exp := int64(unit), 0
-    for n := b / unit; n >= unit; n /= unit {
-        div *= unit
-        exp++
-    }
-    return fmt.Sprintf("%.2f %cB",
-        float64(b)/float64(div), "kMGTPE"[exp])
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %cB",
+		float64(b)/float64(div), "kMGTPE"[exp])
 }
 
 func GetTeamserverPath() string {
-    var (
-        Path string
-        err  error
-    )
+	cwd, err := os.Getwd()
+	if err != nil {
+		logger.Error("Couldn't get current working directory of teamserver: " + err.Error())
+		return ""
+	}
 
-    if Path, err = os.Getwd(); err != nil {
-        logger.Error("Couldn't get current working directory of teamserver: " + err.Error())
-        return ""
-    }
+	if root := locateRepositoryRoot(cwd); root != "" {
+		return root
+	}
 
-    return Path
+	return cwd
+}
+
+func locateRepositoryRoot(start string) string {
+	path := start
+	for {
+		if hasPayloads(path) {
+			return path
+		}
+
+		parent := filepath.Dir(path)
+		if parent == path {
+			return ""
+		}
+		path = parent
+	}
+}
+
+func hasPayloads(path string) bool {
+	info, err := os.Stat(filepath.Join(path, "payloads"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
 }
 
 /*func GetFieldName(fieldPinter interface{}) (name string) {
@@ -129,17 +153,17 @@ func GetTeamserverPath() string {
 }*/
 
 func IntToHexString(Int int) string {
-    return fmt.Sprintf("%x", Int)
+	return fmt.Sprintf("%x", Int)
 }
 
 func HexIntToString(HexInt int) string {
-    var bs = make([]byte, 4)
-    binary.LittleEndian.PutUint32(bs, uint32(HexInt))
-    return fmt.Sprintf("%x", binary.BigEndian.Uint32(bs))
+	var bs = make([]byte, 4)
+	binary.LittleEndian.PutUint32(bs, uint32(HexInt))
+	return fmt.Sprintf("%x", binary.BigEndian.Uint32(bs))
 }
 
 func HexIntToBigEndian(HexInt int) int {
-    var bs = make([]byte, 4)
-    binary.LittleEndian.PutUint32(bs, uint32(HexInt))
-    return int(binary.BigEndian.Uint32(bs))
+	var bs = make([]byte, 4)
+	binary.LittleEndian.PutUint32(bs, uint32(HexInt))
+	return int(binary.BigEndian.Uint32(bs))
 }


### PR DESCRIPTION
## Summary
- surface gate console messages and payload artifacts in the headless client so operators immediately see build failures or where payloads were saved
- add collision-safe output handling when writing stageless payloads returned by the teamserver
- document the automated gate logging and payload persistence in the headless workflow guide
- resolve teamserver path detection so builder operations locate the shared payload sources when the binaries are launched from the teamserver directory

## Testing
- GOPROXY=off GOSUMDB=off go build ./cmd/headless *(fails: module downloads require network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e505ff5c8083328913fd16ebadf5ca